### PR TITLE
fix(deps): remediate critical dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2610,13 +2610,14 @@
       "dev": true
     },
     "node_modules/handlebars": {
-      "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
+        "neo-async": "^2.6.2",
         "source-map": "^0.6.1",
         "wordwrap": "^1.0.0"
       },
@@ -6749,7 +6750,7 @@
       "requires": {
         "conventional-commits-filter": "^2.0.7",
         "dateformat": "^3.0.0",
-        "handlebars": "^4.7.7",
+        "handlebars": "4.7.9",
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.17.15",
         "meow": "^8.0.0",
@@ -7798,13 +7799,13 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
+        "neo-async": "^2.6.2",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.29.0",
     "standard-version": "^9.5.0"
+  },
+  "overrides": {
+    "handlebars": "4.7.9"
   }
 }


### PR DESCRIPTION
## Summary
- Add npm override for transitive `handlebars@4.7.9`.
- Regenerate `package-lock.json`.

## Critical advisories addressed
- https://github.com/drugoi/telegram-bot-qazlatyn/security/dependabot/47
- GHSA-2w6w-674q-4c4q / CVE-2026-33937: Handlebars.js JavaScript injection via AST type confusion

## Dependency files changed
- `package.json`
- `package-lock.json`

## Verification
- `npm ci` - passed
- `npm ls handlebars` - resolves `handlebars@4.7.9`
- `npm audit --audit-level=critical` - passed; remaining max severity is high
- `npm test` - passed, 5 tests

## Remaining non-critical alerts
This PR intentionally addresses critical alerts only. High, medium, and low Dependabot alerts remain for a later pass.
